### PR TITLE
Added github URL

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Description: Provides functions and classes to compute, handle and visualise
   for outbreak analysis.
 Encoding: UTF-8
 License: MIT + file LICENSE
-URL: https://www.repidemicsconsortium.org/incidence/
+URL: https://www.repidemicsconsortium.org/incidence/, https://github.com/reconhub/incidence
 BugReports: https://github.com/reconhub/incidence/issues
 RoxygenNote: 7.1.1
 Imports:


### PR DESCRIPTION
The github URL is added to the description. This will give cran users awareness of the GitHub location.

For an example see https://github.com/tidyverse/dplyr/blob/main/DESCRIPTION     